### PR TITLE
Crear dockerfile básico para la API

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,11 @@
+#Versión de Python que vamos a usar
+FROM python:3.13.5-slim
+
+#Establecemos el directorio de trabajo
+WORKDIR /app
+
+#Copiamos la lista de dependencias
+COPY requirements.txt .
+
+#Instalamos las dependencias
+RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
Añadimos un dockerfile básico que permite instalar las dependencias requeridas.